### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,9 +49,8 @@ urllib3==1.22
 Werkzeug==1.0.0
 wheel==0.34.2
 xxhash==1.4.3
-fuzzywuzzy==0.18.0
+rapidfuzz==0.2.0
 pytest==5.3.5
-python-Levenshtein==0.12.0
 peewee==3.13.1
 gevent==1.4.0
 gevent_inotifyx==0.2

--- a/rowboat/plugins/admin.py
+++ b/rowboat/plugins/admin.py
@@ -8,7 +8,7 @@ import operator
 from io import StringIO
 from peewee import fn
 from disco.util.emitter import Priority
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.